### PR TITLE
TNR-2200: Create the cloudwatch log group explicitly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .terraform/
 *.tfstate*
+.idea

--- a/iam.tf
+++ b/iam.tf
@@ -63,6 +63,13 @@ resource "aws_iam_policy_attachment" "logs" {
   policy_arn = "${aws_iam_policy.logs.arn}"
 }
 
+resource "aws_cloudwatch_log_group" "logs" {
+  count = "${var.enable_cloudwatch_logs ? 1 : 0}"
+
+  name = "/aws/lambda/${var.function_name}"
+  tags = "${var.tags}"
+}
+
 # Attach an additional policy required for the dead letter config.
 
 data "aws_iam_policy_document" "dead_letter" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,13 @@ output "role_name" {
   description = "The name of the IAM role created for the Lambda function"
   value       = "${aws_iam_role.lambda.name}"
 }
+
+output "log_group_arn" {
+  description = "The ARN of the cloudwatch log group (if enabled)"
+  value       = "${var.enable_cloudwatch_logs ? aws_cloudwatch_log_group.logs.arn : ""}"
+}
+
+output "log_group_name" {
+  description = "The name of the cloudwatch log group (if enabled)"
+  value       = "${var.enable_cloudwatch_logs ? aws_cloudwatch_log_group.logs.name : ""}"
+}


### PR DESCRIPTION
This is to help resolve an issue where we're using a log group
subscription, but the actual log group is created implicitly when the
lambda function first runs.  Since it's not created explicitly during
terraform plan, the subscription can't be wired up and everything dies