### PR TITLE
TNR-2200: Clean up warnings

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -20,10 +20,10 @@ output "role_name" {
 
 output "log_group_arn" {
   description = "The ARN of the cloudwatch log group (if enabled)"
-  value       = "${var.enable_cloudwatch_logs ? aws_cloudwatch_log_group.logs.arn : ""}"
+  value       = "${element(concat(aws_cloudwatch_log_group.logs.*.arn, list("")), 0)}"
 }
 
 output "log_group_name" {
   description = "The name of the cloudwatch log group (if enabled)"
-  value       = "${var.enable_cloudwatch_logs ? aws_cloudwatch_log_group.logs.name : ""}"
+  value       = "${element(concat(aws_cloudwatch_log_group.logs.*.name, list("")), 0)}"
 }


### PR DESCRIPTION
Follow-up to deal with the following warning:
Warning: output "log_group_arn": must use splat syntax to access aws_cloudwatch_log_group.logs attribute "arn", because it has "count" set; use aws_cloudwatch_log_group.logs.*.arn to obtain a list of the attributes across all instances